### PR TITLE
Use https:// in url maps

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ option,
 .. code-block:: python
 
    javadoc_url_map = {
-       'com.netflix.curator' : ('http://netflix.github.com/curator/doc', 'javadoc'),
+       'com.netflix.curator' : ('https://netflix.github.com/curator/doc', 'javadoc'),
        'org.springframework' : ('http://static.springsource.org/spring/docs/3.1.x/javadoc-api/', 'javadoc'),
        'org.springframework.data.redis' : ('http://static.springsource.org/spring-data/data-redis/docs/current/api/', 'javadoc')
    }
@@ -64,7 +64,7 @@ source, and ``doc_type`` is one of,
 
 When comparing referenced types to the list of available packages the longest
 match will be used. Entries for ``java``, ``javax``, ``org.xml``, and
-``org.w3c`` packages pointing to http://docs.oracle.com/javase/8/docs/api are
+``org.w3c`` packages pointing to https://docs.oracle.com/javase/8/docs/api are
 included automatically and do not need to be defined explicitly.
 
 .. _JDK-8144118: https://bugs.openjdk.java.net/browse/JDK-8144118

--- a/javasphinx/extdoc.py
+++ b/javasphinx/extdoc.py
@@ -24,13 +24,13 @@ def get_javadoc_ref(app, rawtext, text):
 
     # Add default Java SE sources
     if not javadoc_url_map.get("java"):
-        javadoc_url_map["java"] = ("http://docs.oracle.com/javase/8/docs/api", 'javadoc8')
+        javadoc_url_map["java"] = ("https://docs.oracle.com/javase/8/docs/api", 'javadoc8')
     if not javadoc_url_map.get("javax"):
-        javadoc_url_map["javax"] = ("http://docs.oracle.com/javase/8/docs/api", 'javadoc8')
+        javadoc_url_map["javax"] = ("https://docs.oracle.com/javase/8/docs/api", 'javadoc8')
     if not javadoc_url_map.get("org.xml"):
-        javadoc_url_map["org.xml"] = ("http://docs.oracle.com/javase/8/docs/api", 'javadoc8')
+        javadoc_url_map["org.xml"] = ("https://docs.oracle.com/javase/8/docs/api", 'javadoc8')
     if not javadoc_url_map.get("org.w3c"):
-        javadoc_url_map["org.w3c"] = ("http://docs.oracle.com/javase/8/docs/api", 'javadoc8')
+        javadoc_url_map["org.w3c"] = ("https://docs.oracle.com/javase/8/docs/api", 'javadoc8')
 
     source = None
     package = ''


### PR DESCRIPTION
Using HTTPS is best practice and also avoids the following error when
running `make linkcheck`:

(line   40) redirect  http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html - permanently to https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html